### PR TITLE
build: can we drop the getopt patch now?

### DIFF
--- a/recipe/0001-use-conda-getopt.patch
+++ b/recipe/0001-use-conda-getopt.patch
@@ -1,0 +1,33 @@
+From 7d52594327df440af1e40f62e6850a8f1236be3a Mon Sep 17 00:00:00 2001
+From: Lindsey Gray <lindsey.gray@gmail.com>
+Date: Wed, 25 Jun 2025 08:55:26 -0500
+Subject: [PATCH] use conda getopt
+
+---
+ examples/CMakeLists.txt | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+index 0b26cda..1d72dbc 100644
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -40,10 +40,10 @@ if (MSVC)
+   target_compile_definitions(sample PUBLIC -D_CRT_SECURE_NO_WARNINGS)
+   target_compile_definitions(spherical PUBLIC -D_CRT_SECURE_NO_WARNINGS)
+ 
+-  target_link_libraries(siscone_main PRIVATE unofficial::getopt-win32::getopt)
+-  target_link_libraries(siscone_area PRIVATE unofficial::getopt-win32::getopt)
+-  target_link_libraries(siscone_test PRIVATE unofficial::getopt-win32::getopt)
+-  target_link_libraries(times PRIVATE unofficial::getopt-win32::getopt)
+-  target_link_libraries(sample PRIVATE unofficial::getopt-win32::getopt)
+-  target_link_libraries(spherical PRIVATE unofficial::getopt-win32::getopt)
++  target_link_libraries(siscone_main PUBLIC unofficial::getopt-win32::getopt)
++  target_link_libraries(siscone_area PUBLIC unofficial::getopt-win32::getopt)
++  target_link_libraries(siscone_test PUBLIC unofficial::getopt-win32::getopt)
++  target_link_libraries(times PUBLIC unofficial::getopt-win32::getopt)
++  target_link_libraries(sample PUBLIC unofficial::getopt-win32::getopt)
++  target_link_libraries(spherical PUBLIC unofficial::getopt-win32::getopt)
+ endif()
+\ No newline at end of file
+-- 
+2.49.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,12 +9,11 @@ package:
 source:
   url: https://gitlab.com/fastjet/siscone/-/archive/siscone-${{ version }}/siscone-siscone-${{ version }}.tar.gz
   sha256: 689696ca32682f39c0999a66117e673f71b41f41debb46111904f6acdcdb2e6b
-  patches: 0001-use-imported-getopt.patch
+  # patches: 0001-use-imported-getopt.patch
 
 build:
   number: 1
   script:
-    # Get an updated config.sub and config.guess
     - if: unix
       then: cmake "${CMAKE_ARGS}" -DSISCONE_BUILD_EXAMPLES=OFF -DSISCONE_ENABLE_DEBUG=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -S . -B build
     - if: win

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -22,7 +22,7 @@ build:
     - if: unix
       then: cmake --build build --parallel="${CPU_COUNT}"
     - if: win
-      then: cmake --build build --config=Release --parallel="%CPU_COUNT%"
+      then: cmake --build build --config=Release --parallel="%CPU_COUNT%" --verbose
     - cmake --install build
 
 requirements:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,7 +9,7 @@ package:
 source:
   url: https://gitlab.com/fastjet/siscone/-/archive/siscone-${{ version }}/siscone-siscone-${{ version }}.tar.gz
   sha256: 689696ca32682f39c0999a66117e673f71b41f41debb46111904f6acdcdb2e6b
-  # patches: 0001-use-imported-getopt.patch
+  patches: 0001-use-conda-getopt.patch
 
 build:
   number: 1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

getopt 0.1 build 3 should have an appropriately configured cmake now...
If not, doesn't matter, since we have the patch.

Just checking :-)